### PR TITLE
在庫上限以上に注文を行えないように修正

### DIFF
--- a/app/javascript/packs/components/CartItemsComponent/index.tsx
+++ b/app/javascript/packs/components/CartItemsComponent/index.tsx
@@ -35,7 +35,7 @@ export const CartItemsComponent: React.VFC = () => {
         </Grid>
         <Grid item xs={12}>
           <Typography variant="h5">
-            合計金額:{' '}
+            合計金額:
             {new Intl.NumberFormat('ja-JP', {
               style: 'currency',
               currency: 'JPY',

--- a/app/javascript/packs/domains/product/models/index.ts
+++ b/app/javascript/packs/domains/product/models/index.ts
@@ -4,6 +4,7 @@ export type Product = {
   id: number
   name: string
   price: number
+  currnt_stock: number
 }
 
 type ResponseProduct = {

--- a/app/javascript/packs/templates/OrderNewTemplate/CheckOutForm.tsx
+++ b/app/javascript/packs/templates/OrderNewTemplate/CheckOutForm.tsx
@@ -45,13 +45,11 @@ export const CheckOutForm: React.VFC<Props> = ({
   const onStripeFormSubmit = async () => {
     if (selectedPaymentMethodId !== '') {
       onSubmit({
-        payment_method: {
-          payment_method_id: Number(selectedPaymentMethodId),
-          card: {
-            brand: '',
-            exp_month: '',
-            exp_year: '',
-          },
+        id: selectedPaymentMethodId,
+        card: {
+          brand: '',
+          exp_month: '',
+          exp_year: '',
         },
       })
     } else {

--- a/app/javascript/packs/templates/ProductListTemplate/ProductItem.tsx
+++ b/app/javascript/packs/templates/ProductListTemplate/ProductItem.tsx
@@ -1,7 +1,14 @@
 import React from 'react'
-import { Grid, Box, Button, makeStyles } from '@material-ui/core'
+import {
+  Grid,
+  Box,
+  Button,
+  makeStyles,
+  Typography,
+  Tooltip,
+} from '@material-ui/core'
 import { Product } from '../../domains/product/models'
-
+import WarningIcon from '@material-ui/icons/Warning'
 type Props = {
   product: Product
   onSelectProduct: (product: Product) => void
@@ -21,13 +28,22 @@ export const ProductItem: React.VFC<Props> = ({ product, onSelectProduct }) => {
             />
           </Grid>
           <Grid item xs={9}>
-            {product.name}
+            {product.currnt_stock < 50 && (
+              <Tooltip title="在庫が残りわずかです">
+                <WarningIcon />
+              </Tooltip>
+            )}
+            <Typography className={classes.productName} variant="h6">
+              {product.name}
+            </Typography>
           </Grid>
           <Grid item xs={3} className={classes.price}>
-            {new Intl.NumberFormat('ja-JP', {
-              style: 'currency',
-              currency: 'JPY',
-            }).format(product.price)}
+            <Typography variant="h6">
+              {new Intl.NumberFormat('ja-JP', {
+                style: 'currency',
+                currency: 'JPY',
+              }).format(product.price)}
+            </Typography>
           </Grid>
 
           <Grid item xs={12}>
@@ -38,7 +54,7 @@ export const ProductItem: React.VFC<Props> = ({ product, onSelectProduct }) => {
                 onSelectProduct(product)
               }}
             >
-              詳細画面
+              詳細画面へ
             </Button>
           </Grid>
         </Grid>
@@ -48,6 +64,9 @@ export const ProductItem: React.VFC<Props> = ({ product, onSelectProduct }) => {
 }
 
 const useStyles = makeStyles((theme) => ({
+  productName: {
+    display: 'inline',
+  },
   price: {
     textAlign: 'end',
   },

--- a/app/javascript/packs/templates/ProductTemplate/ProductItem.tsx
+++ b/app/javascript/packs/templates/ProductTemplate/ProductItem.tsx
@@ -35,7 +35,7 @@ export const ProductItem: React.VFC<Props> = ({
     [quantity]
   )
   const increase = () => {
-    if (quantity < 100) {
+    if (quantity < product.currnt_stock) {
       const newNumberOfItem = quantity + 1
       setQuantity(newNumberOfItem)
     }
@@ -61,6 +61,9 @@ export const ProductItem: React.VFC<Props> = ({
           </Grid>
           <Grid item xs={3} className={classes.price}>
             <Typography variant="subtitle1">{product.name}</Typography>
+            <Typography variant="subtitle1">
+              在庫数：{product.currnt_stock}
+            </Typography>
             <Typography variant="subtitle2">
               {new Intl.NumberFormat('ja-JP', {
                 style: 'currency',
@@ -83,9 +86,12 @@ export const ProductItem: React.VFC<Props> = ({
                     addToCart(product)
                   }}
                 >
-                  カートに入れる
+                  この商品をカートに入れる
                 </Button>
               </div>
+            )}
+            {quantity > product.currnt_stock && (
+              <div>在庫数以上の注文は行なえません</div>
             )}
           </Grid>
           <Grid item xs={3}>

--- a/app/models/customer_payment_method.rb
+++ b/app/models/customer_payment_method.rb
@@ -3,7 +3,16 @@ class CustomerPaymentMethod < ApplicationRecord
 
   class << self
     def create_stripe_payment_intent(customer, params)
-      unless CustomerPaymentMethod.where(payment_method_id: params[:payment_method][:id]).exists?
+      if CustomerPaymentMethod.where(payment_method_id: params[:payment_method][:id]).exists?
+        Stripe::PaymentIntent.create({
+          customer: customer.stripe_customer_id,
+          amount: params[:total_price],
+          currency: 'jpy',
+          payment_method: params[:payment_method][:id],
+          confirm: true,
+          setup_future_usage: "on_session"
+        })
+      else
         create!(
           customer_id: customer.id,
           payment_method_id: params[:payment_method][:id],
@@ -11,14 +20,15 @@ class CustomerPaymentMethod < ApplicationRecord
           exp_month: params[:payment_method][:card][:exp_month],
           exp_year: params[:payment_method][:card][:exp_year]
         )
+        Stripe::PaymentIntent.create({
+          customer: customer.stripe_customer_id,
+          amount: params[:total_price],
+          currency: 'jpy',
+          payment_method: params[:payment_method][:id],
+          confirm: true,
+          setup_future_usage: "on_session"
+        })
       end
-
-      Stripe::PaymentIntent.create({
-        amount: params[:total_price],
-        currency: 'jpy',
-        payment_method: params[:payment_method][:id],
-        confirm: true
-      })
     end
   end
 end

--- a/app/views/admin/api/v2/products/index.json.jbuilder
+++ b/app/views/admin/api/v2/products/index.json.jbuilder
@@ -1,9 +1,8 @@
-json.cache! ['admin', 'api', 'v2', @products], expires_in: 10.minutes do
-  json.products do
-    json.array! @products do |product|
-      json.id product[:id]
-      json.name product[:name]
-      json.price product.price
-    end
+json.products do
+  json.array! @products do |product|
+    json.id product[:id]
+    json.name product[:name]
+    json.price product.price
+    json.currnt_stock product.currnt_stock
   end
 end


### PR DESCRIPTION
## このPRについて

resolve #9 対応

## 変更点

- バックエンド側から商品の在庫数の情報を送信するように修正
- フロントエンド側は上記の在庫数以上に注文を出せないように修正
- 今回のIssueと関係ないが決済時に登録するクレジットカードが再利用できない状態でPaymentIntent作っていたので setup_future_usageの設定を追加