### PR TITLE
Customer側の画面遷移ロジック修正

### DIFF
--- a/app/javascript/packs/components/PageHeader/index.tsx
+++ b/app/javascript/packs/components/PageHeader/index.tsx
@@ -1,12 +1,14 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { Grid, Box, Button } from '@material-ui/core'
-import { Link } from 'react-router-dom'
+import { Grid, Box, Button, makeStyles } from '@material-ui/core'
+import { Link, useLocation } from 'react-router-dom'
 import { useCurrentCustomer } from '../../components/providers/AuthProvider'
 import { getAuth } from 'firebase/auth'
 
 export const PageHeader: React.VFC = () => {
+  const classes = useStyles({})
   const [currentCustomer, setCurrentCustomer] = useCurrentCustomer()
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false)
+  const location = useLocation()
 
   const onClickSignOut = useCallback(async () => {
     const auth = getAuth()
@@ -43,9 +45,12 @@ export const PageHeader: React.VFC = () => {
             <Box p={1} />
           </Grid>
           <Grid item>
-            <Link to="/orders">
+            <Link
+              className={classes.link}
+              to={location.pathname === '/orders' ? '/products' : '/orders'}
+            >
               <Button variant="contained" color="primary">
-                注文を確認する
+                {location.pathname === '/orders' ? '商品一覧' : '注文一覧'}
               </Button>
             </Link>
           </Grid>
@@ -54,3 +59,8 @@ export const PageHeader: React.VFC = () => {
     </>
   )
 }
+const useStyles = makeStyles(() => ({
+  link: {
+    textDecoration: 'none',
+  },
+}))

--- a/app/javascript/packs/templates/ProductTemplate/ProductItem.tsx
+++ b/app/javascript/packs/templates/ProductTemplate/ProductItem.tsx
@@ -31,6 +31,8 @@ export const ProductItem: React.VFC<Props> = ({
         const newCartItems = cartItems.concat([newCartItem])
         setCartItems(newCartItems)
       }
+
+      resetSelectedProduct()
     },
     [quantity]
   )


### PR DESCRIPTION
## このPRについて

resolve #36 対応

## 変更点

- カートに商品を入れたら一覧画面に自動的に戻るロジックを追加
- 商品一覧と注文一覧を相互に遷移出来るようにPageHeaderコンポーネント修正