### PR TITLE
注文のキャンセル機能

### DIFF
--- a/app/controllers/admin/api/v2/cancellation_orders_controller.rb
+++ b/app/controllers/admin/api/v2/cancellation_orders_controller.rb
@@ -1,0 +1,19 @@
+module Admin
+  module Api
+    module V2
+      class CancellationOrdersController < ApplicationController
+        before_action :verify_token, only: %i[create]
+
+        def create
+          shipping = Operations::RequestCancellationShipping.execute(params[:order_id])
+
+          if shipping
+            render json: { shipping: { id: shipping.id } }, status: :created
+          else
+            render status: :internal_server_error
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/javascript/packs/domains/order/models/index.ts
+++ b/app/javascript/packs/domains/order/models/index.ts
@@ -1,4 +1,4 @@
-import { fetchResources } from '../services'
+import { fetchResources, createCancellationRequestResources } from '../services'
 
 export type Order = {
   id: number
@@ -19,6 +19,15 @@ type OrderResponse = {
 
 export const fetchOrders = async (idToken: string) => {
   const response = await fetchResources(idToken)
+  const result: OrderResponse = await response.json()
+  return result.orders
+}
+
+export const createCancellationRequest = async (
+  idToken: string,
+  order: Order
+) => {
+  const response = await createCancellationRequestResources(idToken, order)
   const result: OrderResponse = await response.json()
   return result.orders
 }

--- a/app/javascript/packs/domains/order/models/index.ts
+++ b/app/javascript/packs/domains/order/models/index.ts
@@ -17,6 +17,12 @@ type OrderResponse = {
   orders: Order[]
 }
 
+type CancellationOrderResponse = {
+  shipping: {
+    id: number
+  }
+}
+
 export const fetchOrders = async (idToken: string) => {
   const response = await fetchResources(idToken)
   const result: OrderResponse = await response.json()
@@ -25,9 +31,9 @@ export const fetchOrders = async (idToken: string) => {
 
 export const createCancellationRequest = async (
   idToken: string,
-  order: Order
+  orderId: number
 ) => {
-  const response = await createCancellationRequestResources(idToken, order)
-  const result: OrderResponse = await response.json()
-  return result.orders
+  const response = await createCancellationRequestResources(idToken, orderId)
+  const result: CancellationOrderResponse = await response.json()
+  return result.shipping
 }

--- a/app/javascript/packs/domains/order/services/index.ts
+++ b/app/javascript/packs/domains/order/services/index.ts
@@ -1,3 +1,5 @@
+import { Order } from '../models'
+
 export const fetchResources = async (idToken: string) => {
   const url = `${process.env.REACT_APP_ORIGIN}/admin/api/v2/orders`
   return await fetch(url, {
@@ -5,4 +7,24 @@ export const fetchResources = async (idToken: string) => {
       Authorization: `Bearer ${idToken}`,
     },
   })
+}
+
+export const createCancellationRequestResources = async (
+  idToken: string,
+  order: Order
+) => {
+  const url = `${process.env.REACT_APP_ORIGIN}/admin/api/v2/cancellation_orders`
+  const data = {
+    order,
+  }
+  const params = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${idToken}`,
+    },
+    body: JSON.stringify(data),
+  }
+
+  return await fetch(url, params)
 }

--- a/app/javascript/packs/domains/order/services/index.ts
+++ b/app/javascript/packs/domains/order/services/index.ts
@@ -1,5 +1,3 @@
-import { Order } from '../models'
-
 export const fetchResources = async (idToken: string) => {
   const url = `${process.env.REACT_APP_ORIGIN}/admin/api/v2/orders`
   return await fetch(url, {
@@ -11,11 +9,11 @@ export const fetchResources = async (idToken: string) => {
 
 export const createCancellationRequestResources = async (
   idToken: string,
-  order: Order
+  orderId: number
 ) => {
   const url = `${process.env.REACT_APP_ORIGIN}/admin/api/v2/cancellation_orders`
   const data = {
-    order,
+    order_id: orderId,
   }
   const params = {
     method: 'POST',

--- a/app/javascript/packs/pages/OrderList/index.tsx
+++ b/app/javascript/packs/pages/OrderList/index.tsx
@@ -1,5 +1,9 @@
-import React, { useEffect, useState } from 'react'
-import { Order, fetchOrders } from '../../domains/order/models'
+import React, { useEffect, useState, useCallback } from 'react'
+import {
+  Order,
+  fetchOrders,
+  createCancellationRequest,
+} from '../../domains/order/models'
 import { useCurrentCustomer } from '../../components/providers/AuthProvider'
 
 import { OrderListTemplate } from '../../templates/OrderListTemplate'
@@ -17,7 +21,17 @@ export const OrderList: React.VFC = () => {
     fetchData()
   }, [])
 
+  const onCancellationRequest = useCallback(async (order: Order) => {
+    const result = await createCancellationRequest(idToken, order)
+    console.log(result)
+  }, [])
+
   if (orders.length === 0) return <>Loading...</>
 
-  return <OrderListTemplate orders={orders} />
+  return (
+    <OrderListTemplate
+      orders={orders}
+      onCancellationRequest={onCancellationRequest}
+    />
+  )
 }

--- a/app/javascript/packs/pages/OrderList/index.tsx
+++ b/app/javascript/packs/pages/OrderList/index.tsx
@@ -7,9 +7,12 @@ import {
 import { useCurrentCustomer } from '../../components/providers/AuthProvider'
 
 import { OrderListTemplate } from '../../templates/OrderListTemplate'
+import { Snackbar } from '@material-ui/core'
 
 export const OrderList: React.VFC = () => {
   const [orders, setOrders] = useState<Order[]>([])
+  const [isRefetch, setIsRefetch] = useState<boolean>(false)
+  const [open, setOpen] = useState(false)
   const [currentCustomer] = useCurrentCustomer()
   const { idToken } = currentCustomer
 
@@ -21,17 +24,39 @@ export const OrderList: React.VFC = () => {
     fetchData()
   }, [])
 
+  useEffect(() => {
+    async function fetchData() {
+      const result = await fetchOrders(idToken)
+      setOrders(result)
+    }
+    fetchData()
+  }, [isRefetch])
+
   const onCancellationRequest = useCallback(async (order: Order) => {
-    const result = await createCancellationRequest(idToken, order)
-    console.log(result)
+    console.log('onCancellationRequest')
+    const result = await createCancellationRequest(idToken, order.id)
+    if (result) {
+      setIsRefetch(true)
+      setOpen(true)
+    }
   }, [])
 
   if (orders.length === 0) return <>Loading...</>
 
   return (
-    <OrderListTemplate
-      orders={orders}
-      onCancellationRequest={onCancellationRequest}
-    />
+    <>
+      <OrderListTemplate
+        orders={orders}
+        onCancellationRequest={onCancellationRequest}
+      />
+      <Snackbar
+        open={open}
+        autoHideDuration={3000}
+        onClose={() => {
+          setOpen(false)
+        }}
+        message="注文のキャンセルを受け付けました"
+      />
+    </>
   )
 }

--- a/app/javascript/packs/templates/OrderListTemplate/OrderItem.tsx
+++ b/app/javascript/packs/templates/OrderListTemplate/OrderItem.tsx
@@ -1,11 +1,15 @@
 import React from 'react'
-import { Box, Typography, Grid, Divider } from '@material-ui/core'
+import { Box, Typography, Grid, Divider, Button } from '@material-ui/core'
 import { Order } from '../../domains/order/models'
 
 type Props = {
   order: Order
+  onCancellationRequest: (order: Order) => void
 }
-export const OrderItem: React.VFC<Props> = ({ order }) => {
+export const OrderItem: React.VFC<Props> = ({
+  order,
+  onCancellationRequest,
+}) => {
   const orderStatus =
     order.status === 'ShippingRequest'
       ? '注文受付'
@@ -32,10 +36,10 @@ export const OrderItem: React.VFC<Props> = ({ order }) => {
             </Typography>
           </Grid>
           {order.orderItems.length > 0 &&
-            order.orderItems.map((orderItem) => {
+            order.orderItems.map((orderItem, index) => {
               return (
                 <Grid
-                  key={orderItem.productName}
+                  key={`${orderItem.productName}-${index}`}
                   container
                   justifyContent="flex-start"
                   alignItems="center"
@@ -54,7 +58,19 @@ export const OrderItem: React.VFC<Props> = ({ order }) => {
               )
             })}
           <Grid item xs={12}>
-            <Divider />
+            <Button
+              onClick={() => onCancellationRequest(order)}
+              variant="contained"
+              color="secondary"
+              disabled={order.status === 'ShippingComplete'}
+            >
+              注文をキャンセル
+            </Button>
+          </Grid>
+          <Grid item xs={12}>
+            <Box p={3}>
+              <Divider />
+            </Box>
           </Grid>
         </Grid>
       </Box>

--- a/app/javascript/packs/templates/OrderListTemplate/OrderItem.tsx
+++ b/app/javascript/packs/templates/OrderListTemplate/OrderItem.tsx
@@ -62,7 +62,7 @@ export const OrderItem: React.VFC<Props> = ({
               onClick={() => onCancellationRequest(order)}
               variant="contained"
               color="secondary"
-              disabled={order.status === 'ShippingComplete'}
+              disabled={order.status !== 'ShippingRequest'}
             >
               注文をキャンセル
             </Button>

--- a/app/javascript/packs/templates/OrderListTemplate/OrderItem.tsx
+++ b/app/javascript/packs/templates/OrderListTemplate/OrderItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, Typography, Grid } from '@material-ui/core'
+import { Box, Typography, Grid, Divider } from '@material-ui/core'
 import { Order } from '../../domains/order/models'
 
 type Props = {
@@ -53,6 +53,9 @@ export const OrderItem: React.VFC<Props> = ({ order }) => {
                 </Grid>
               )
             })}
+          <Grid item xs={12}>
+            <Divider />
+          </Grid>
         </Grid>
       </Box>
     </>

--- a/app/javascript/packs/templates/OrderListTemplate/index.tsx
+++ b/app/javascript/packs/templates/OrderListTemplate/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Grid, Divider } from '@material-ui/core'
+import { Grid } from '@material-ui/core'
 import { Order } from '../../domains/order/models'
 import { OrderItem } from './OrderItem'
 
@@ -12,14 +12,9 @@ export const OrderListTemplate: React.VFC<Props> = ({ orders }) => {
       <Grid container>
         {orders.map((order) => {
           return (
-            <div key={order.id}>
-              <Grid item xs={12}>
-                <OrderItem order={order} />
-              </Grid>
-              <Grid item xs={12}>
-                <Divider />
-              </Grid>
-            </div>
+            <Grid item xs={12}>
+              <OrderItem key={order.id} order={order} />
+            </Grid>
           )
         })}
       </Grid>

--- a/app/javascript/packs/templates/OrderListTemplate/index.tsx
+++ b/app/javascript/packs/templates/OrderListTemplate/index.tsx
@@ -5,16 +5,26 @@ import { OrderItem } from './OrderItem'
 
 type Props = {
   orders: Order[]
+  onCancellationRequest: (order: Order) => void
 }
-export const OrderListTemplate: React.VFC<Props> = ({ orders }) => {
+export const OrderListTemplate: React.VFC<Props> = ({
+  orders,
+  onCancellationRequest,
+}) => {
   return (
     <>
       <Grid container>
         {orders.map((order) => {
           return (
-            <Grid item xs={12}>
-              <OrderItem key={order.id} order={order} />
-            </Grid>
+            <div key={order.id}>
+              <Grid item xs={12}>
+                <OrderItem
+                  key={order.id}
+                  order={order}
+                  onCancellationRequest={onCancellationRequest}
+                />
+              </Grid>
+            </div>
           )
         })}
       </Grid>

--- a/app/models/operations/request_cancellation_shipping.rb
+++ b/app/models/operations/request_cancellation_shipping.rb
@@ -1,0 +1,16 @@
+module Operations
+  class RequestCancellationShipping
+    class << self
+      def execute(order_id)
+        # NOTE: 注文キャンセルは現状単にリクエストを受け付けるだけを想定仕様にしてる
+        # そのためShippingのキャンセル注文受け付け相当のレコードだけ作成すればよい。
+        # キャンセルに伴う在庫調整はcancellation_completeの処理時に行う
+        order = Order.find(order_id)
+        Shipping.create(
+          order: order,
+          status: Shipping.statuses[:cancellation_request]
+        )        
+      end
+    end
+  end
+end

--- a/app/models/operations/request_cancellation_shipping.rb
+++ b/app/models/operations/request_cancellation_shipping.rb
@@ -9,7 +9,7 @@ module Operations
         Shipping.create(
           order: order,
           status: Shipping.statuses[:cancellation_request]
-        )        
+        )
       end
     end
   end

--- a/app/models/shipping.rb
+++ b/app/models/shipping.rb
@@ -1,7 +1,13 @@
 class Shipping < ApplicationRecord
   belongs_to :order
 
-  enum status: { shipping_request: 1, shipping_in_ready: 2, shipping_complete: 3 }
+  enum status: {
+    shipping_request: 1,
+    shipping_in_ready: 2,
+    cancellation_request: 3,
+    cancellation_complete: 4,
+    shipping_complete: 5
+  }
 
   scope :target_order_ids, lambda { |status|
     group(:order_id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       namespace :v2, defaults: { format: :json } do
         resources :products, only: %i[index show]
         resources :orders, only: %i[index show create]
+        resources :cancellation_orders, only: %i[create]
         resources :customers, only: %i[show create]
         resources :customer_payment_methods, only: %i[index show]
       end

--- a/spec/requests/admin/api/v2/cancellation_orders_spec.rb
+++ b/spec/requests/admin/api/v2/cancellation_orders_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin::Api::V2::CancellationOrders', type: :request do
+  let(:customer) { create(:customer) }
+  let!(:order1) { create(:order, customer: customer) }
+
+  context '認証ユーザーからのリクエストの場合' do
+    let(:headers) do
+      {
+        'Content-Type': 'application/json',
+        Authorization: "Bearer #{customer.uid}"
+      }
+    end
+
+    before do
+      allow(AuthToken).to receive(:verify).and_return({ uid: customer.uid }.deep_stringify_keys)
+    end
+
+    describe 'POST /admin/api/v2/cancellation_orders' do
+      subject do
+        post '/admin/api/v2/cancellation_orders', params: order_params.to_json, headers: headers
+        JSON.parse(response.body)
+      end
+
+      let(:order_params) do
+        {
+          order_id: order1.id
+        }
+      end
+
+      it 'キャンセル受付に関連してshippingレコードが存在する' do
+        expect(subject['shipping'].present?).to eq true
+      end
+    end
+  end
+
+  context 'id_tokenに何も設定されていないリクエストの場合' do
+    let(:headers) do
+      {
+        'Content-Type': 'application/json'
+      }
+    end
+
+    before do
+      allow(AuthToken).to receive(:verify).and_return({ uid: 'valid-uid' }.deep_stringify_keys)
+    end
+
+    describe 'POST /admin/api/v2/cancellation_orders' do
+      subject do
+        JSON.parse(response.body)
+      end
+
+      let(:order_params) do
+        {
+          order_id: order1.id
+        }
+      end
+
+      it 'キャンセル受付に関連してshippingレコードが存在する' do
+        post '/admin/api/v2/cancellation_orders', params: order_params.to_json, headers: headers
+        expect(response.status).to eq 401
+      end
+    end
+  end
+end


### PR DESCRIPTION
## このPRについて

resolve #38 対応

## 変更点

- Customer側の画面から注文キャンセルできるように対応
  - 注文一覧画面でレイアウトが崩れていたので合わせてその部分も修正
- 注文のキャンセルデーターを作成するという文脈として捉えてるためCancellationOrdersContorollerを通じて処理をする構造で対応

## 動作確認

![Nov-11-2021 16-02-17](https://user-images.githubusercontent.com/950924/141252964-19d6cb25-db27-4d16-b90e-036a62e733de.gif)
