### PR TITLE
注文キャンセル確定処理時にStripeのRefundの処理を実施する

### DIFF
--- a/app/models/shipping_state.rb
+++ b/app/models/shipping_state.rb
@@ -32,6 +32,10 @@ class ShippingState < ApplicationRecord
       transitions from: :shipping_request, to: :cancellation_complete
     end
 
+    event :ship_cancel_request do
+      transitions from: :shipping_request, to: :cancellation_request
+    end
+
     event :ship_decline do
       transitions from: :shipping_in_ready, to: :cancellation_complete
     end

--- a/app/usecases/fix_cancellation_shipping.rb
+++ b/app/usecases/fix_cancellation_shipping.rb
@@ -5,10 +5,15 @@ class FixCancellationShipping
       return if order.blank?
 
       ActiveRecord::Base.transaction do
+        Stripe::Refund.create(
+          {
+            payment_intent: order.payment_intent_id
+          }
+        )
         shipping_state = ShippingState.find_by(
           order_id: order_id
         )
-        shipping_state.ship_decline!
+        shipping_state.cancel_complete!
         order.order_items.each do |order_item|
           product = Product.find_by!(name: order_item[:product_name])
 

--- a/app/usecases/request_cancellation_shipping.rb
+++ b/app/usecases/request_cancellation_shipping.rb
@@ -7,7 +7,7 @@ class RequestCancellationShipping
       shipping_state = ShippingState.find_by(
         order_id: order_id
       )
-      shipping_state.ship_cancel!
+      shipping_state.ship_cancel_request!
     end
   end
 end

--- a/spec/usecases/fix_cancellation_shipping_spec.rb
+++ b/spec/usecases/fix_cancellation_shipping_spec.rb
@@ -8,12 +8,14 @@ RSpec.describe FixCancellationShipping, type: :model do
 
     before do
       create(:product_stock, product: product, stock: 2)
-      create(:order_item, order_id: order.id, product_name: product.name, product_unit_price: product.price,
+      create(:order_item, order_id: order.id,
+                          product_name: product.name,
+                          product_unit_price: product.price,
                           quantity: 1)
       shipping_state = create(:shipping_state, order: order)
-      shipping_state.ship_ready!
-      striple_intent_spy = spy(Stripe::PaymentIntent) # rubocop:disable RSpec/VerifiedDoubles
-      allow(Stripe::PaymentIntent).to receive(:create).and_return(striple_intent_spy)
+      shipping_state.cancellation_request!
+      striple_intent_spy = spy(Stripe::Refund) # rubocop:disable RSpec/VerifiedDoubles
+      allow(Stripe::Refund).to receive(:create).and_return(striple_intent_spy)
     end
 
     context '既存の在庫数の範囲内で注文を受け付けた場合' do


### PR DESCRIPTION
## このPRについて

resolve #44 対応