### PR TITLE
Customer側の画面で注文のキャンセルと出荷のキャンセルの処理を出し分け

### DIFF
--- a/app/javascript/packs/templates/OrderListTemplate/OrderItem.tsx
+++ b/app/javascript/packs/templates/OrderListTemplate/OrderItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import { Box, Typography, Grid, Divider, Button } from '@material-ui/core'
 import { Order } from '../../domains/order/models'
 
@@ -6,16 +6,40 @@ type Props = {
   order: Order
   onCancellationRequest: (order: Order) => void
 }
+
+type OrderStatusType = {
+  status:
+    | 'ShippingRequest'
+    | 'ShippingInReady'
+    | 'CancellationRequest'
+    | 'CancellationComplete'
+    | 'ShippingComplete'
+  label: string
+}
 export const OrderItem: React.VFC<Props> = ({
   order,
   onCancellationRequest,
 }) => {
-  const orderStatus =
-    order.status === 'ShippingRequest'
-      ? '注文受付'
-      : order.status === 'ShippingInReady'
-      ? '出荷準備完了'
-      : '出荷完了'
+  const OrderStatusMaster: OrderStatusType[] = [
+    { status: 'ShippingRequest', label: '注文受付' },
+    { status: 'ShippingInReady', label: '出荷準備完了' },
+    { status: 'CancellationRequest', label: '注文・出荷キャンセル依頼中' },
+    { status: 'CancellationComplete', label: '注文・出荷キャンセル完了' },
+    { status: 'ShippingComplete', label: '出荷完了' },
+  ]
+
+  const [currentOrderStatus, setCurrentOrderStatus] = useState('')
+
+  useEffect(() => {
+    const orderStatus = OrderStatusMaster.find((item) => {
+      return item.status === order.status
+    })
+
+    if (orderStatus) {
+      setCurrentOrderStatus(orderStatus.label)
+    }
+  }, [order])
+
   return (
     <>
       <Box p={1}>
@@ -24,7 +48,9 @@ export const OrderItem: React.VFC<Props> = ({
             <Typography variant="h5">注文ID：{order.id}</Typography>
           </Grid>
           <Grid item xs={12}>
-            <Typography variant="h6">注文ステータス：{orderStatus}</Typography>
+            <Typography variant="h6">
+              注文ステータス：{currentOrderStatus}
+            </Typography>
           </Grid>
           <Grid item xs={12}>
             <Typography variant="h6">
@@ -63,14 +89,18 @@ export const OrderItem: React.VFC<Props> = ({
               variant="contained"
               color="secondary"
               disabled={
-                ['ShippingRequest', 'CancellationRequest'].includes(
-                  order.status
-                )
+                [
+                  'ShippingRequest',
+                  'ShippingInReady',
+                  'CancellationRequest',
+                ].includes(order.status)
                   ? false
                   : true
               }
             >
-              注文をキャンセル
+              {order.status === 'ShippingInReady'
+                ? '出荷取消を依頼'
+                : '注文キャンセルを依頼'}
             </Button>
           </Grid>
           <Grid item xs={12}>

--- a/app/models/shipping_state.rb
+++ b/app/models/shipping_state.rb
@@ -36,8 +36,8 @@ class ShippingState < ApplicationRecord
       transitions from: :shipping_request, to: :cancellation_request
     end
 
-    event :ship_decline do
-      transitions from: :shipping_in_ready, to: :cancellation_complete
+    event :ship_decline_request do
+      transitions from: :shipping_in_ready, to: :cancellation_request
     end
 
     event :cancel_complete do

--- a/app/usecases/request_cancellation_shipping.rb
+++ b/app/usecases/request_cancellation_shipping.rb
@@ -7,7 +7,12 @@ class RequestCancellationShipping
       shipping_state = ShippingState.find_by(
         order_id: order_id
       )
-      shipping_state.ship_cancel_request!
+      if shipping_state.shipping_request?
+        shipping_state.ship_cancel_request!
+      else
+        shipping_state.ship_decline_request!
+      end
+      shipping_state
     end
   end
 end

--- a/spec/usecases/request_cancellation_shipping_spec.rb
+++ b/spec/usecases/request_cancellation_shipping_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe RequestCancellationShipping, type: :model do
+  describe '.execute' do
+    let(:customer) { create(:customer) }
+    let(:product) { create(:product, price: 1000) }
+    let(:order) { create(:order, customer: customer) }
+    let!(:shipping_state) { create(:shipping_state, order: order) }
+
+    before do
+      create(:product_stock, product: product, stock: 2)
+      create(:order_item, order_id: order.id,
+                          product_name: product.name,
+                          product_unit_price: product.price,
+                          quantity: 1)
+    end
+
+    context '注文の状態が受付完了の場合' do
+      subject(:response) { described_class.execute(order.id) }
+
+      it 'shipping_stateの状態はship_cancel_requestになる' do
+        expect(response.cancellation_request?).to eq true
+      end
+    end
+
+    context '注文の状態が出荷準備完了の場合' do
+      subject(:response) { described_class.execute(order.id) }
+
+      before do
+        shipping_state.shipping_in_ready!
+      end
+
+      it 'shipping_stateの状態はship_cancel_requestになる' do
+        expect(response.cancellation_request?).to eq true
+      end
+    end
+
+    context '注文の状態が出荷済の場合' do
+      subject(:response) { described_class.execute(order.id) }
+
+      before do
+        shipping_state.shipping_in_ready!
+        shipping_state.shipping_complete!
+      end
+
+      it 'AASM::InvalidTransitionの例外が発生する' do
+        expect { response }.to raise_error AASM::InvalidTransition
+      end
+    end
+  end
+end


### PR DESCRIPTION
## このPRについて

resolve #46 対応

## 変更点

- Customer側の画面では注文ステータスによって「注文キャンセル」or 「出荷取り消し」のどちらかをボタンのラベルに表示するロジックに修正
- Customer側からのリクエストを受けて、注文ステータスによってShippingStateの処理を適切な値に更新
  - 関連するspecも作成